### PR TITLE
Fix User Icon in System Tray

### DIFF
--- a/gnome-shell/gnome-shell.css
+++ b/gnome-shell/gnome-shell.css
@@ -877,7 +877,7 @@ StScrollBar {
 }
 
 .system-switch-user-submenu-icon {
-	icon-size: 48px;
+	icon-size: 16px;
 	border: none; }
 
 #appMenu {


### PR DESCRIPTION
Unusually large user icon in the System Tray. Adjusted to 16px. (not sure if this was intended).

Edit: Amazing Theme BTW. Love both the Dark and Light versions of this theme!