### PR TITLE
Fix Volume OSD - gnome-shell.css

### DIFF
--- a/gnome-shell/gnome-shell.css
+++ b/gnome-shell/gnome-shell.css
@@ -476,7 +476,7 @@ StScrollBar {
 	.osd-window .level {
 		height: 0.6em;
 		border-radius: 0.3em;
-		background-color: rgba(25,25,25,1.0);
+		background-color: rgba(25,25,25,0.1);
 		color: white; }
 
 /* App Switcher (alt-tab) */
@@ -550,7 +550,6 @@ StScrollBar {
 	border-radius: 6px; }
 
 /* Alt-tab shadow color*/
-.osd-window,
 .resize-popup,
 .switcher-list, .workspace-switcher-container {
 	color: #5c5c5c;


### PR DESCRIPTION
Update gnome-shell.css to fix the OSD Volume Window. This fix should change the OSD Volume Icon and Level Bar white.