### PR TITLE
Fix Volume OSD - gnome-shell.css

### DIFF
--- a/gnome-shell/gnome-shell.css
+++ b/gnome-shell/gnome-shell.css
@@ -470,7 +470,8 @@ StScrollBar {
 	spacing: 1em;
 	margin: 32px;
 	min-width: 64px;
-	min-height: 64px; }
+	min-height: 64px;
+	background-color: rgba(0,0,0,0.6); }
 	.osd-window .osd-monitor-label {
 		font-size: 3em; }
 	.osd-window .level {

--- a/gnome-shell/gnome-shell.css
+++ b/gnome-shell/gnome-shell.css
@@ -476,7 +476,7 @@ StScrollBar {
 	.osd-window .level {
 		height: 0.6em;
 		border-radius: 0.3em;
-		background-color: rgba(25,25,25,1.0);
+		background-color: rgba(25,25,25,0.1);
 		color: white; }
 
 /* App Switcher (alt-tab) */
@@ -550,7 +550,6 @@ StScrollBar {
 	border-radius: 6px; }
 
 /* Alt-tab shadow color*/
-.osd-window,
 .resize-popup,
 .switcher-list, .workspace-switcher-container {
 	color: #5c5c5c;

--- a/gnome-shell/gnome-shell.css
+++ b/gnome-shell/gnome-shell.css
@@ -471,7 +471,8 @@ StScrollBar {
 	margin: 32px;
 	min-width: 64px;
 	min-height: 64px;
-	background-color: rgba(0,0,0,0.6); }
+	background-color: rgba(0,0,0,0.6);
+	color: #fff; }
 	.osd-window .osd-monitor-label {
 		font-size: 3em; }
 	.osd-window .level {


### PR DESCRIPTION
Update gnome-shell.css to fix the OSD Volume Window. This fix should change the OSD Volume Icon and Level Bar white. (Resubmitted to make volume theme more inline with the overall theme)